### PR TITLE
Add configuration option to restrict by column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ Below screenshoot is from the sample table.
 
 ![](https://github.com/kracekumar/datasette-render-local-images/blob/main/sample.png)
 
+## Only apply to specific column names 
+
+Optionally create a list of column names that this should apply to (ignoring other columns).
+
+``` python
+{
+    "plugins": {
+        "datasette-render-local-images": {
+            "height": 150,
+            "width": 150,
+            "column_names": ["profile_pic", "alternate_pic"]
+        }
+    }
+}
+```
+
 ## Development
 
 To set up this plugin locally, first checkout the code. Then create a new virtual environment:

--- a/datasette_render_local_images/__init__.py
+++ b/datasette_render_local_images/__init__.py
@@ -14,6 +14,8 @@ def get_size_to_render(plugin_config):
 
 def get_local_path(value):
     """Get local path for the value."""
+    if not isinstance(value, str):
+        return ""
     value = Path(value)
     # Return if exists and a file
     if value.exists() and value.is_file():
@@ -22,12 +24,17 @@ def get_local_path(value):
 
 
 @hookimpl
-def render_cell(value, datasette):
+def render_cell(value, column, datasette):
     """Render local image in any cell.
     """
     if datasette:
         plugin_config = datasette.plugin_config("datasette-render-local-images") or {}
         height, width = get_size_to_render(plugin_config)
+        column_names = plugin_config.get("column_names")
+
+    #If column name isn't listed as image path, skip
+    if column_names and column not in column_names:
+        return None
 
     # If the path exists then go ahead
     path = get_local_path(value)


### PR DESCRIPTION
I added a configuration option for my own local use.  It was helpful when python was throwing exceptions for fields with large unicode strings. Hopefully it is useful for you too. 